### PR TITLE
fix: modify order of loading the config to ensure that reuse_output c…

### DIFF
--- a/vrtool/run_workflows/measures_workflow/run_measures.py
+++ b/vrtool/run_workflows/measures_workflow/run_measures.py
@@ -55,6 +55,8 @@ class RunMeasures(VrToolRunProtocol):
         # Get measurements solutions
         logging.info("Start step 2: evaluation of measures.")
         _results_measures = ResultsMeasures()
+        _results_measures.vr_config = self.vr_config
+        _results_measures.selected_traject = self.selected_traject
         if self.vr_config.reuse_output:
             _results_measures.load_results()
         else:
@@ -62,13 +64,11 @@ class RunMeasures(VrToolRunProtocol):
                 dict(map(self._get_section_solution, self.selected_traject.sections))
             )
 
-        for i in self.selected_traject.sections:
-            _results_measures.solutions_dict[i.name].solutions_to_dataframe(
-                filtering="off", splitparams=True
-            )
+            for i in self.selected_traject.sections:
+                _results_measures.solutions_dict[i.name].solutions_to_dataframe(
+                    filtering="off", splitparams=True
+                )
 
-        _results_measures.selected_traject = self.selected_traject
-        _results_measures.vr_config = self.vr_config
 
         # Store intermediate results:
         if self.vr_config.shelves:

--- a/vrtool/run_workflows/optimization_workflow/run_optimization.py
+++ b/vrtool/run_workflows/optimization_workflow/run_optimization.py
@@ -190,6 +190,7 @@ class RunOptimization(VrToolRunProtocol):
     def run(self) -> ResultsOptimization:
         logging.info("Start step 3: Optimization")
         _results_optimization = ResultsOptimization()
+        _results_optimization.vr_config = self.vr_config
         if self.vr_config.reuse_output:
             _results_optimization.load_results()
         else:
@@ -205,7 +206,6 @@ class RunOptimization(VrToolRunProtocol):
 
         logging.info("Finished step 3: Optimization")
         _results_optimization.selected_traject = self.selected_traject
-        _results_optimization.vr_config = self.vr_config
         _results_optimization.results_solutions = self._solutions_dict
         if self.vr_config.shelves:
             _results_optimization.save_results()


### PR DESCRIPTION
…an actually be used in the workflow

Original problem was that there was (e.g. in run_measures) a call to self.vr_config.reuse_output but the config was not loaded yet.