### PR TITLE
fix: if mechanism not relevant, assume beta = 10

### DIFF
--- a/vrtool/decision_making/solutions.py
+++ b/vrtool/decision_making/solutions.py
@@ -132,15 +132,8 @@ class Solutions:
                     _mechanism_names = list(map(str, self.mechanisms))
                     for ij in _mechanism_names + ["Section"]:
                         if ij not in betas.index:
-                            # TODO (VRTOOL-187).
-                            # It seems the other mechanisms are not including Revetment in their measure calculations, therefore failing.
-                            # This could happen in the future for other 'new' mechanisms.
-                            reliability_in.extend([-999] * len(self.config.T))
-                            logging.warning(
-                                "Measure '{}' does not contain data for mechanism '{}', using 'nan' instead.".format(
-                                    measure.parameters["Name"], ij
-                                )
-                            )
+                            # If a mechanism has not been computed it is irrelevant so the beta is assumed to be 10.
+                            reliability_in.extend([10.0] * len(self.config.T))
                             continue
                         for ijk in betas.loc[ij].values:
                             reliability_in.append(ijk)
@@ -199,15 +192,8 @@ class Solutions:
                 )
                 for ij in _mechanism_names + ["Section"]:
                     if ij not in betas.index:
-                        # TODO (VRTOOL-187).
-                        # It seems the other mechanisms are not including Revetment in their measure calculations, therefore failing.
-                        # This could happen in the future for other 'new' mechanisms.
-                        beta.extend([-999] * len(self.config.T))
-                        logging.warning(
-                            "Measure '{}' does not contain data for mechanism '{}', using 'nan' instead.".format(
-                                measure.parameters["Name"], ij
-                            )
-                        )
+                        # If a mechanism has not been computed it is irrelevant so the beta is assumed to be 10.
+                        beta.extend([10.0] * len(self.config.T))
                         continue
                     for ijk in betas.loc[ij].values:
                         beta.append(ijk)

--- a/vrtool/decision_making/strategies/strategy_base.py
+++ b/vrtool/decision_making/strategies/strategy_base.py
@@ -249,7 +249,7 @@ class StrategyBase:
                 solutions_dict[section.name].MeasureData.loc["cost"] = [1e60]
                 for beta_type in section.section_reliability.SectionReliability.index:
                     beta_array_investment_year[beta_type] = np.full(
-                        (1, np.max(self.T)), 8.0
+                        (1, np.max(self.T)), 10.0
                     )
             else:
                 for beta_type in section.section_reliability.SectionReliability.index:
@@ -332,7 +332,7 @@ class StrategyBase:
                                         len(self.indexCombined2single[section.name]),
                                         np.arange(0, np.max(self.T), 1).shape[0],
                                     ),
-                                    8.0,
+                                    10.0,
                                 ),
                                 columns=pd.MultiIndex.from_product(
                                     [[mechanism_name], np.arange(0, np.max(self.T), 1)]


### PR DESCRIPTION
Removed warning as this is completely logical based on the input (i.e. if you don't give input for revetment you would not expect a beta to be returned). Warning might cause unnecessary confusion among users.