### PR TITLE
chore: Improved logic to import `OrmMeasureResult` for optimizations.

### DIFF
--- a/vrtool/optimization/measures/measure_as_input_protocol.py
+++ b/vrtool/optimization/measures/measure_as_input_protocol.py
@@ -85,3 +85,18 @@ class MeasureAsInputProtocol(Protocol):
                 `None` means no secondary measure is needed
         """
         pass
+
+    @staticmethod
+    def is_combinable_type_allowed(combinable_type: CombinableTypeEnum) -> bool:
+        """
+        Verifies whether the given combinable type can be created as an instance
+        of this `MeasureAsInputProtocol` type.
+
+        Args:
+            combinable_type (CombinableTypeEnum): Combinable type to be checked.
+
+        Returns:
+            bool: This combinable type can be represented as this
+            `MeasureAsInputProtocol` instance.
+        """
+        pass

--- a/vrtool/optimization/measures/sg_measure.py
+++ b/vrtool/optimization/measures/sg_measure.py
@@ -92,6 +92,14 @@ class SgMeasure(MeasureAsInputProtocol):
             CombinableTypeEnum.FULL: [None],
         }
 
+    @staticmethod
+    def is_combinable_type_allowed(combinable_type: CombinableTypeEnum) -> bool:
+        return combinable_type in [
+            CombinableTypeEnum.FULL,
+            CombinableTypeEnum.COMBINABLE,
+            CombinableTypeEnum.PARTIAL,
+        ]
+
     def is_initial_cost_measure(self) -> bool:
         if self.year != 0:
             return False

--- a/vrtool/optimization/measures/sh_measure.py
+++ b/vrtool/optimization/measures/sh_measure.py
@@ -96,6 +96,14 @@ class ShMeasure(MeasureAsInputProtocol):
             CombinableTypeEnum.FULL: [None, CombinableTypeEnum.REVETMENT],
         }
 
+    @staticmethod
+    def is_combinable_type_allowed(combinable_type: CombinableTypeEnum) -> bool:
+        return combinable_type in [
+            CombinableTypeEnum.FULL,
+            CombinableTypeEnum.COMBINABLE,
+            CombinableTypeEnum.REVETMENT,
+        ]
+
     def is_initial_cost_measure(self) -> bool:
         if self.year != 0:
             return False

--- a/vrtool/orm/io/importers/optimization/optimization_measure_result_importer.py
+++ b/vrtool/orm/io/importers/optimization/optimization_measure_result_importer.py
@@ -134,10 +134,16 @@ class OptimizationMeasureResultImporter(OrmImporterProtocol):
 
         _imported_measures = []
 
-        if self.valid_parameter(orm_model, "dberm"):
+        _combinable_type = CombinableTypeEnum.get_enum(orm_model.combinable_type_name)
+
+        if self.valid_parameter(
+            orm_model, "dberm"
+        ) and ShMeasure.is_combinable_type_allowed(_combinable_type):
             _imported_measures.extend(self._create_measure(orm_model, ShMeasure))
 
-        if self.valid_parameter(orm_model, "dcrest"):
+        if self.valid_parameter(
+            orm_model, "dcrest"
+        ) and SgMeasure.is_combinable_type_allowed(_combinable_type):
             _imported_measures.extend(self._create_measure(orm_model, SgMeasure))
 
         if not _imported_measures:

--- a/vrtool/orm/models/measure_result/measure_result.py
+++ b/vrtool/orm/models/measure_result/measure_result.py
@@ -21,10 +21,28 @@ class MeasureResult(OrmBaseModel):
         """
         Returns the name of the related `MeasureType` table entry.
 
+        !DESIGN DECISION!: We return a string rather than an enum
+        to prevent the `vrtool.orm.models` to import / have knowledge
+        over datastructures present outside said subproject.
+
         Returns:
             str: The name in capital letters.
         """
         return self.measure_per_section.measure.measure_type.name.upper()
+
+    @property
+    def combinable_type_name(self) -> str:
+        """
+        Returns the name of the related `CombinableType` table entry.
+
+        !DESIGN DECISION!: We return a string rather than an enum
+        to prevent the `vrtool.orm.models` to import / have knowledge
+        over datastructures present outside said subproject.
+
+        Returns:
+            str: The name in capital letters.
+        """
+        return self.measure_per_section.measure.combinable_type.name.upper()
 
     def get_parameter_value(self, parameter_name: str) -> float:
         """


### PR DESCRIPTION
## Issue addressed
Solves VRTOOL-512

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [ ] I HAVE discussed my solution with (other) members of the VRTOOL team.

## What has been done?
- Added logic to quickly retrieve the `CombinableType.name` related to a `MeasureResult`.
- Added logic to filter out creation of `ShMeasure` or `SgMeasure` based on the allowed `CombinableTypeEnum` values.

### Checklist
- [ ] Tests are either added or updated.
- [x] Branch is up to date with `main`.
- [x] Updated documentation if needed.

## Additional Notes (optional)
Pair-programming with @ArdtK .
From our perspective the reason on why we get a "Custom Measure" is its combinable type, as when being 'full' you will get it both as  `ShMeasure` and `SgMeasure`.
