### PR TITLE
Fix: VRTOOL-521 l stab screen as cost index

### DIFF
--- a/vrtool/orm/io/importers/optimization/measures/sg_measure_importer.py
+++ b/vrtool/orm/io/importers/optimization/measures/sg_measure_importer.py
@@ -22,16 +22,18 @@ class SgMeasureImporter(MeasureAsInputBaseImporter):
         def is_initial_cost_measure(sg_measure: SgMeasure) -> bool:
             if sg_measure.year != 0:
                 return False
-            return math.isnan(sg_measure.l_stab_screen) and (
-                math.isclose(sg_measure.dberm, 0) or math.isnan(sg_measure.dberm)
-            )
+            return math.isclose(sg_measure.dberm, 0) or math.isnan(sg_measure.dberm)
 
-        _cost_dictionary = defaultdict(lambda: 0.0)
+        _cost_dictionary = defaultdict(lambda: defaultdict(lambda: 0.0))
         for _sg_measure in filter(is_initial_cost_measure, measure_as_input_collection):
-            _cost_dictionary[_sg_measure.measure_type] = _sg_measure.cost
+            _cost_dictionary[_sg_measure.measure_type][
+                _sg_measure.l_stab_screen
+            ] = _sg_measure.cost
 
         for _sg_measure in measure_as_input_collection:
-            _base_cost = _cost_dictionary[_sg_measure.measure_type]
+            _base_cost = _cost_dictionary[_sg_measure.measure_type][
+                _sg_measure.l_stab_screen
+            ]
             if _sg_measure.measure_type not in [
                 MeasureTypeEnum.SOIL_REINFORCEMENT,
                 MeasureTypeEnum.SOIL_REINFORCEMENT_WITH_STABILITY_SCREEN,

--- a/vrtool/orm/io/importers/optimization/measures/sh_measure_importer.py
+++ b/vrtool/orm/io/importers/optimization/measures/sh_measure_importer.py
@@ -22,16 +22,18 @@ class ShMeasureImporter(MeasureAsInputBaseImporter):
         def is_initial_cost_measure(sh_measure: ShMeasure) -> bool:
             if sh_measure.year != 0:
                 return False
-            return math.isnan(sh_measure.l_stab_screen) and (
-                math.isclose(sh_measure.dcrest, 0) or math.isnan(sh_measure.dcrest)
-            )
+            return math.isclose(sh_measure.dcrest, 0) or math.isnan(sh_measure.dcrest)
 
-        _cost_dictionary = defaultdict(lambda: 0.0)
+        _cost_dictionary = defaultdict(lambda: defaultdict(lambda: 0.0))
         for _sh_measure in filter(is_initial_cost_measure, measure_as_input_collection):
-            _cost_dictionary[_sh_measure.measure_type] = _sh_measure.cost
+            _cost_dictionary[_sh_measure.measure_type][
+                _sh_measure.l_stab_screen
+            ] = _sh_measure.cost
 
         for _sh_measure in measure_as_input_collection:
-            _base_cost = _cost_dictionary[_sh_measure.measure_type]
+            _base_cost = _cost_dictionary[_sh_measure.measure_type][
+                _sh_measure.l_stab_screen
+            ]
             if _sh_measure.measure_type not in [
                 MeasureTypeEnum.VERTICAL_PIPING_SOLUTION,
                 MeasureTypeEnum.DIAPHRAGM_WALL,


### PR DESCRIPTION
## Issue addressed
Solves VRTOOL-521 (First problem)

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [x] I HAVE discussed my solution with (other) members of the VRTOOL team.

## What has been done?
Simply extend the dictionary to 'pivot' over the different `l_stab_screen` value combinations with `dberm` / `dcrest` 0 (base / initial measures).

### Checklist
- [ ] Tests are either added or updated.
- [ ] Branch is up to date with `main`.
- [ ] Updated documentation if needed.

## Additional Notes (optional)
This PR is dependent of #315 
