### PR TITLE
ci: Extended postStartCommand to copy test externals

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
     "source=${localWorkspaceFolder},target=/usr/src/app,type=bind,consistency=cached",
     "source=vrtool_dev_container,target=/usr/src/.env,type=volume"
   ],
-  "postStartCommand": "poetry install & git config --global core.autocrlf true & git config --global --add safe.directory ${containerWorkspaceFolder}",
+  "postStartCommand": "cp -r /usr/src/test_externals/ /usr/src/app/tests/ & poetry install & git config --global core.autocrlf true & git config --global --add safe.directory ${containerWorkspaceFolder}",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
## Issue addressed
None created.

## Code of conduct
- [ ] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [ ] I HAVE NOT added vulnerabilities to the repository.
- [ ] I HAVE discussed my solution with (other) members of the VRTOOL team.

## What has been done?
- Extended `postStartCommand` so that it also copies the test_externals into the correct directory.

### Checklist
- [ ] Tests are either added or updated.
- [ ] Branch is up to date with `main`.
- [ ] Updated documentation if needed.

## Additional Notes (optional)
This is done to reduce overhead for future developers / codespaces. It has no effect whatsoever in TeamCity.
