### PR TITLE
fix:add TARGET as StepType

### DIFF
--- a/vrtool/common/enums/step_type_enum.py
+++ b/vrtool/common/enums/step_type_enum.py
@@ -7,6 +7,7 @@ class StepTypeEnum(VrtoolEnum):
     UNKNOWN = 0
     SINGLE = 1
     BUNDLING = 2
+    TARGET = 3
 
     @classmethod
     def get_enum(cls, enum_name: str) -> StepTypeEnum:

--- a/vrtool/decision_making/strategies/target_reliability_strategy.py
+++ b/vrtool/decision_making/strategies/target_reliability_strategy.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 import numpy as np
 
 from vrtool.common.enums.mechanism_enum import MechanismEnum
+from vrtool.common.enums.step_type_enum import StepTypeEnum
 from vrtool.decision_making.strategies.strategy_protocol import StrategyProtocol
 from vrtool.decision_making.strategies.strategy_step import StrategyStep
 from vrtool.decision_making.traject_risk import TrajectRisk
@@ -37,7 +38,7 @@ class TargetReliabilityStrategy(StrategyProtocol):
         self.OI_horizon = config.OI_horizon
         self.time_periods = config.T
         self.sections = strategy_input.sections
-        self.initial_step = StrategyStep(step_number=0)
+        self.initial_step = StrategyStep(step_number=0, step_type = StepTypeEnum.TARGET)
         self.optimization_steps = []
 
         self.traject_risk = TrajectRisk(strategy_input.Pf, strategy_input.D)
@@ -468,6 +469,7 @@ class TargetReliabilityStrategy(StrategyProtocol):
             self.optimization_steps.append(
                 StrategyStep(
                     step_number=len(self.optimization_steps) + 1,
+                    step_type=StepTypeEnum.TARGET,
                     measure=_measure,
                     section_idx=_section_idx,
                     aggregated_measure=_valid_measures[idx],


### PR DESCRIPTION
## Issue addressed
Solves VRTOOL-601. In particular the small test finding to use TARGET rather than UNKNOWN as value for target reliability.

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [x] I HAVE discussed my solution with (other) members of the VRTOOL team.

## What has been done?
Explain how you addressed the resolution of the related issue, what choices you made and why.

### Checklist
- [ ] Tests are either added or updated.
- [x] Branch is up to date with `main`.
- [x] Updated documentation if needed.

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
